### PR TITLE
Adding TransactionProducer to Simplify Threading

### DIFF
--- a/src/edu/cscc/Main.java
+++ b/src/edu/cscc/Main.java
@@ -1,5 +1,6 @@
 package edu.cscc;
 
+import edu.cscc.transactions.TransactionProducer;
 import edu.cscc.transactions.TransactionsReader;
 
 import java.io.File;
@@ -12,6 +13,7 @@ public class Main {
         try {
             FileReader fileReader = new FileReader("." + File.separator + "rental_transactions.csv");
             TransactionsReader transactionsReader = new TransactionsReader(fileReader);
+            TransactionProducer transactionProducer = new TransactionProducer(transactionsReader);
             //TODO Implement the solution here.
         } catch (FileNotFoundException e) {
             e.printStackTrace();

--- a/src/edu/cscc/transactions/TransactionProducer.java
+++ b/src/edu/cscc/transactions/TransactionProducer.java
@@ -1,0 +1,29 @@
+package edu.cscc.transactions;
+
+public class TransactionProducer {
+
+    private TransactionsReader transactionsReader;
+    private TransactionsReader.TransactionIterator iterator;
+
+    public TransactionProducer(TransactionsReader transactionsReader) {
+        this.transactionsReader = transactionsReader;
+        iterator = (TransactionsReader.TransactionIterator) this.transactionsReader.iterator();
+    }
+
+    public synchronized Transaction peek() {
+        return iterator.peek();
+    }
+
+    public synchronized boolean hasNext() {
+        return peek() != null;
+    }
+
+    public synchronized Transaction next() {
+        Transaction transaction = iterator.next();
+        if (transaction != null) {
+            return transaction;
+        }
+
+        return null;
+    }
+}

--- a/src/edu/cscc/transactions/TransactionsReader.java
+++ b/src/edu/cscc/transactions/TransactionsReader.java
@@ -62,7 +62,7 @@ public class TransactionsReader implements Iterable<Transaction> {
          * @return true if another record can be read, false otherwise.
          */
         @Override
-        public boolean hasNext() {
+        public synchronized boolean hasNext() {
             try {
                 return csvReader.peek() != null;
             } catch (IOException e) {
@@ -73,11 +73,26 @@ public class TransactionsReader implements Iterable<Transaction> {
         }
 
         /**
+         * If there is another record to be read return
+         * that record without advancing to the next record.
+         * @return The next record if there is one, null otherwise.
+         */
+        public synchronized Transaction peek() {
+            try {
+                String[] peek = csvReader.peek();
+                if (peek != null) return ConvertTransaction.convert(peek);
+                return null;
+            } catch (IOException e) {
+                return null;
+            }
+        }
+
+        /**
          * Read the next transaction.
          * @return A {@link Transaction}, or null if one is not available.
          */
         @Override
-        public Transaction next() {
+        public synchronized Transaction next() {
             try {
                 return ConvertTransaction.convert(csvReader.readNext());
             } catch (IOException e) {


### PR DESCRIPTION
# Context
The current approach for this lab asks students to create a class which implements an iterator-like interface. This PR simplifies the problem-space around threading by providing this class for them.

# Changes
- Implemented the TransactionProducer. This class provides synchronized `hasNext()`, `peek()`, and `next()` access to the TransactionReader.
- Updated TransactionReader to provided a synchronized `peek()` method. Making `next()` and `hasNext()` synchronized.